### PR TITLE
refactor chunk processing, and add variable replacement in markdown

### DIFF
--- a/imd_poc/chunks/base.py
+++ b/imd_poc/chunks/base.py
@@ -1,8 +1,15 @@
 from abc import ABC, abstractmethod
+from collections import namedtuple
 import copy
 from typing import List, Union
 
+import attr
 import panflute as pf
+
+@attr.s
+class ChunkResult:
+    block: Union[None, pf.Block] = attr.ib(default=None)
+    metadata: dict = attr.ib(factory=dict)
 
 
 class BaseChunk(ABC):
@@ -31,9 +38,9 @@ class BaseChunk(ABC):
         self.doc_metadata = copy.deepcopy(doc_metadata)
 
     @abstractmethod
-    def process_chunk(self, *, text: str, options: dict) -> Union[pf.Block, None]:
+    def process_chunk(self, *, text: str, options: dict) -> ChunkResult:
         """Process the chunk, and return a pandoc block level element."""
-        return None
+        pass
 
     def clean_up(self):
         """Called after all chunks in a document have been processed."""

--- a/imd_poc/chunks/julia.py
+++ b/imd_poc/chunks/julia.py
@@ -2,7 +2,7 @@ from typing import List, Union
 
 import panflute as pf
 
-from .base import BaseChunk
+from .base import BaseChunk, ChunkResult
 
 
 class JuliaChunk(BaseChunk):
@@ -18,6 +18,6 @@ class JuliaChunk(BaseChunk):
         """Return a list of supported output formats."""
         return ["markdown", "html", "latex", "rst"]
 
-    def process_chunk(self, *, text: str, options: dict) -> Union[pf.Block, None]:
+    def process_chunk(self, *, text: str, options: dict) -> ChunkResult:
         """Process the chunk, and return a pandoc block level element."""
-        return pf.CodeBlock(text, classes=["julia"])
+        return ChunkResult(pf.CodeBlock(text, classes=["julia"]))

--- a/imd_poc/chunks/note.py
+++ b/imd_poc/chunks/note.py
@@ -2,7 +2,7 @@ from typing import List, Union
 
 import panflute as pf
 
-from .base import BaseChunk
+from .base import BaseChunk, ChunkResult
 
 
 class NoteChunk(BaseChunk):
@@ -20,7 +20,7 @@ class NoteChunk(BaseChunk):
         """Return a list of supported output types."""
         return ["markdown", "html", "latex", "rst"]
 
-    def process_chunk(self, *, text: str, options: dict) -> Union[pf.Block, None]:
+    def process_chunk(self, *, text: str, options: dict) -> ChunkResult:
         """Process the chunk, and return a pandoc block level element."""
         # TODO merge doc and chunk metadata
         color = ""
@@ -30,13 +30,13 @@ class NoteChunk(BaseChunk):
             color = self.doc_metadata["chunk_defaults"]["note"]["color"]
         if self.output_fmt == "latex":
             if color:
-                return pf.RawBlock(
+                return ChunkResult(pf.RawBlock(
                     f"\\begin{{note}}[color={color}]\n{text}\\end{{note}}", format="tex"
-                )
+                ))
             else:
-                return pf.RawBlock(
+                return ChunkResult(pf.RawBlock(
                     f"\\begin{{note}}\n{text}\\end{{note}}", format="tex"
-                )
-        return pf.Div(
+                ))
+        return ChunkResult(pf.Div(
             *pf.convert_text(text), classes=["note"], attributes={"color": color}
-        )
+        ))

--- a/imd_poc/main.py
+++ b/imd_poc/main.py
@@ -1,11 +1,13 @@
 import re
+from textwrap import dedent
 from typing import Dict, TextIO, Type, Union
 
 import panflute as pf
+from panflute.tools import meta2builtin
 import pyparsing as pp
 import yaml
 
-from imd_poc.chunks.base import BaseChunk
+from imd_poc.chunks.base import BaseChunk, ChunkResult
 from imd_poc.utils import file_to_doc, find_entry_point
 
 REGEX_DOCMETA = re.compile(
@@ -17,8 +19,71 @@ REGEX_CHUNK = re.compile(
     r"(?:\n|\r\n?)\`\`\`\{([a-zA-Z]+)([^(?:\n|\r\n?)]*)\}\s*(?:\n|\r\n?)([^?!\`\`\`]*)\`\`\`(?:\n|\r\n?)",
     re.DOTALL,
 )
+CHUNK_CLASS = "imd-chunk"
 REF_ENTRY_GROUP = "imd.references"
 REGEX_REFERENCE = re.compile(r"@(.+)\(([^\)]+)\)")
+REGEX_VARIABLE = re.compile(r"^\{\{([^\:]+)\:(.*)\}\}$")
+
+
+def process_doc(path: Union[str, TextIO], output_fmt: str):
+    with open(path) as handle:
+        # we add line breaks either side,
+        # to make sure the multi-line regexes work
+        content = "\n" + handle.read().rstrip() + "\n"
+
+    # reformat chunks into `pandoc.Div`s
+    # we do this before pandoc conversion, because pandoc does not inherently support chunks,
+    # but ideally there would be better pandoc integration
+    while True:
+        try:
+            match = next(REGEX_CHUNK.finditer(content))
+        except StopIteration:
+            break
+        chunk_type = match.group(1)
+        options = parse_chunk_options(match.group(2))
+        chunk_content = match.group(3)
+        # note textwrap dedent doesn't seem to work properly
+        new_block = f"""\
+:::{{.{CHUNK_CLASS} type={chunk_type}}}
+```options
+{yaml.safe_dump(options)}
+```
+```content
+{chunk_content}
+```
+:::
+"""
+        content = (
+            content[: match.start()]
+            + "\n\n"
+            + new_block
+            + "\n\n"
+            + content[match.end() :]
+        )
+
+    # parse document into pandoc AST
+    doc = pf.convert_text(content, standalone=True)  # type; pf.Doc
+    doc.format = output_fmt
+    doc.builtin_meta = meta2builtin(doc.metadata)
+    doc.chunk_converters = {}  # type: Dict[str, BaseChunk]
+    doc.chunk_data = {}
+
+    # process chunks
+    # we do this in a try/finally block, to ensure all 'opened' converters are cleaned up,
+    # if an error is raised
+    try:
+        doc.walk(process_chunks)
+    finally:
+        # call each converter to clean up, e.g. close running a kernels
+        for converter in doc.chunk_converters.values():
+            try:
+                converter.clean_up()
+            except:
+                pass
+
+    doc.walk(format_references)
+
+    return doc
 
 
 def convert_value(value):
@@ -63,80 +128,32 @@ def parse_chunk_options(string: str) -> dict:
     return output
 
 
-def process_doc(path: Union[str, TextIO], output_fmt: str):
-    with open(path) as handle:
-        # we add line breaks either side,
-        # to make sure the multi-line regexes work
-        content = new_content = "\n" + handle.read().rstrip() + "\n"
+def process_chunks(el: pf.Element, doc: pf.Doc):
+    """Process a chunk."""
 
-    # load the document metadata
-    doc_metadata = {}
-    meta_match = REGEX_DOCMETA.findall(content)
-    if meta_match:
-        doc_metadata = yaml.safe_load(meta_match[0])
-
-    chunk_converters = {}  # type: Dict[str, BaseChunk]
-    chunk_outputs = []
-    # process chunks and insert placeholders
-    # we do this before pandoc conversion, because pandoc does not inherently support chunks,
-    # but ideally there would be better pandoc integration
-    # we do this in a try/finally block, to ensure all 'opened' converters are cleaned up, if an error is raised
-    try:
-        for match in REGEX_CHUNK.finditer(content):
-            chunk_type = match.group(1)
-            # instantiate a converter for the type
-            if chunk_type not in chunk_converters:
-                chunk_cls = find_entry_point(
-                    chunk_type, CHUNK_ENTRY_GROUP
-                )  # type: Type[BaseChunk]
-                chunk_converters[chunk_type] = chunk_cls(
-                    output_fmt=output_fmt, doc_metadata=doc_metadata
-                )  # TODO doc metadata
-            # print(parse_chunk_options(match.group(2)))
-            chunk_outputs.append(
-                chunk_converters[chunk_type].process_chunk(
-                    text=match.group(3), options=parse_chunk_options(match.group(2))
-                )
+    if isinstance(el, pf.Div) and CHUNK_CLASS in el.classes:
+        chunk_type = el.attributes["type"]
+        options = yaml.safe_load(el.content[0].text)
+        content = el.content[1].text
+        if chunk_type not in doc.chunk_converters:
+            chunk_cls = find_entry_point(
+                chunk_type, CHUNK_ENTRY_GROUP
+            )  # type: Type[BaseChunk]
+            doc.chunk_converters[chunk_type] = chunk_cls(
+                output_fmt=doc.format, doc_metadata=doc.builtin_meta
             )
-            # We replace the original chunk with a 'placeholder', that can be easily
-            # iterated through, once the document is converted to pandoc AST
-            new_content = (
-                new_content[: match.start()]
-                + f"\n```{'-'*(match.end() - match.start()-9)}\n```\n"
-                + new_content[match.end() :]
-            )
-    finally:
-        # call each converter to close down, e.g. if the are running a kernel
-        for converter in chunk_converters.values():
-            try:
-                converter.clean_up()
-            except:
-                pass
+        result = doc.chunk_converters[chunk_type].process_chunk(
+            text=content, options=options
+        )  # type: ChunkResult
+        doc.chunk_data[chunk_type] = result.metadata
+        return result.block
 
-    # parse document into pandoc AST
-    doc = pf.convert_text(new_content, standalone=True)  # type; pf.Doc
-    doc.format = output_fmt
-
-    # insert chunk output back into documents
-    doc_content = []
-    for el in doc.content:
-        if (
-            isinstance(el, pf.CodeBlock)
-            and el.classes
-            and el.classes[0].startswith("-")
-        ):
-            output = chunk_outputs.pop(0)
-            if output:
-                doc_content.append(output)
-        else:
-            doc_content.append(el)
-    doc.content = doc_content
-
-    doc.walk(format_references)
-    # raise
-
-    return doc
-
+    if isinstance(el, pf.Str):
+        match = REGEX_VARIABLE.match(el.text)
+        if match and "variables" in doc.chunk_data.get(match.group(1), {}):
+            replace = doc.chunk_data[match.group(1)]["variables"].get(match.group(2), None)
+            if replace is not None:
+                return pf.Str(str(replace))
 
 def format_references(el: pf.Element, doc: pf.Doc):
     if not isinstance(el, pf.Str):
@@ -145,8 +162,12 @@ def format_references(el: pf.Element, doc: pf.Doc):
     for match in REGEX_REFERENCE.finditer(el.text):
         ref_type = match.group(1)
         refs = match.group(2)
-        ref_cls = find_entry_point(ref_type, REF_ENTRY_GROUP)(output_fmt=doc.format, doc_metadata=doc.metadata)
-        replacements.append((ref_cls.process_reference(refs, {}), match.start(), match.end()))
+        ref_cls = find_entry_point(ref_type, REF_ENTRY_GROUP)(
+            output_fmt=doc.format, doc_metadata=doc.metadata
+        )
+        replacements.append(
+            (ref_cls.process_reference(refs, {}), match.start(), match.end())
+        )
     if replacements:
         # TODO handle if the replacement is not the the entire string,
         # or if there are multiple references

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name="imd-poc",
     author="Chris Sewell",
     packages=find_packages(),
-    install_requires=["nbformat", "nbconvert", "pyyaml", "panflute", "pyparsing"],
+    install_requires=["attrs", "nbformat", "nbconvert", "pyyaml", "panflute", "pyparsing"],
     extras_require={"testing": ["pytest", "pytest-regressions", "pandas"]},
     entry_points={
         "imd.chunks": [

--- a/tests/test.imd
+++ b/tests/test.imd
@@ -19,7 +19,7 @@ Some inline math: $x = y + z$
 Some display math:
 
 $$
-\begin{equation} 
+\begin{equation}
   f\left(k\right) = \binom{n}{k} p^k\left(1-p\right)^{n-k}
 \end{equation}
 $$
@@ -31,9 +31,14 @@ This is a note.
 This is some more text.
 
 ```{python}
+import os
 a = 1
+b = "I'm a replacement"
+c = 1.0
 print(f"a = {a}")
 ```
+
+{{python:b}}
 
 ```{python eval=False}
 a += 1
@@ -49,6 +54,8 @@ print(f"a = {a}")
 a += 1
 print(f"a = {a}")
 ```
+
+{{python:a}}
 
 ```{julia, eval=False}
 using Calculus

--- a/tests/test_imd_converter/test_process_doc1_html__html_.html
+++ b/tests/test_imd_converter/test_process_doc1_html__html_.html
@@ -89,7 +89,7 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
 <p>Some inline math: <span class="math inline"><em>x</em> = <em>y</em> + <em>z</em></span></p>
 <p>Some display math:</p>
 <p><br /><span class="math display">$$
-\begin{equation} 
+\begin{equation}
   f\left(k\right) = \binom{n}{k} p^k\left(1-p\right)^{n-k}
 \end{equation}
 $$</span><br /></p>
@@ -98,16 +98,27 @@ $$</span><br /></p>
 </div>
 <p>This is some more text.</p>
 <div class="code-cell">
-<div class="sourceCode" id="cb1"><pre class="sourceCode python"><code class="sourceCode python"><span id="cb1-1"><a href="#cb1-1"></a>a <span class="op">=</span> <span class="dv">1</span></span>
-<span id="cb1-2"><a href="#cb1-2"></a><span class="bu">print</span>(<span class="ss">f&quot;a = </span><span class="sc">{a}</span><span class="ss">&quot;</span>)</span></code></pre></div>
+<div class="sourceCode" id="cb1"><pre class="sourceCode python"><code class="sourceCode python"><span id="cb1-1"><a href="#cb1-1"></a><span class="im">import</span> os</span>
+<span id="cb1-2"><a href="#cb1-2"></a>a <span class="op">=</span> <span class="dv">1</span></span>
+<span id="cb1-3"><a href="#cb1-3"></a>b <span class="op">=</span> <span class="st">&quot;I&#39;m a replacement&quot;</span></span>
+<span id="cb1-4"><a href="#cb1-4"></a>c <span class="op">=</span> <span class="fl">1.0</span></span>
+<span id="cb1-5"><a href="#cb1-5"></a><span class="bu">print</span>(<span class="ss">f&quot;a = </span><span class="sc">{a}</span><span class="ss">&quot;</span>)</span></code></pre></div>
 <div class="outputs">
 <p>a = 1
 </p>
 </div>
 </div>
+<p>I'm a replacement</p>
 <div class="code-cell">
 <div class="sourceCode" id="cb2"><pre class="sourceCode python"><code class="sourceCode python"><span id="cb2-1"><a href="#cb2-1"></a>a <span class="op">+=</span> <span class="dv">1</span></span>
 <span id="cb2-2"><a href="#cb2-2"></a><span class="bu">print</span>(<span class="ss">f&quot;a = </span><span class="sc">{a}</span><span class="ss">&quot;</span>)</span></code></pre></div>
+</div>
+<div class="imd-chunk" type="python">
+<pre class="options"><code>{include: false}
+</code></pre>
+<pre class="content"><code>a += 1
+print(f&quot;a = {a}&quot;)
+</code></pre>
 </div>
 <div class="code-cell">
 <div class="outputs">
@@ -115,7 +126,8 @@ $$</span><br /></p>
 </p>
 </div>
 </div>
-<div class="sourceCode" id="cb3"><pre class="sourceCode julia"><code class="sourceCode julia"><span id="cb3-1"><a href="#cb3-1"></a>using Calculus</span>
-<span id="cb3-2"><a href="#cb3-2"></a>derivative(x -&gt; sin(x), <span class="fl">1.0</span>)</span></code></pre></div>
+<p>3</p>
+<div class="sourceCode" id="cb5"><pre class="sourceCode julia"><code class="sourceCode julia"><span id="cb5-1"><a href="#cb5-1"></a>using Calculus</span>
+<span id="cb5-2"><a href="#cb5-2"></a>derivative(x -&gt; sin(x), <span class="fl">1.0</span>)</span></code></pre></div>
 </body>
 </html>

--- a/tests/test_imd_converter/test_process_doc1_latex__tex_.tex
+++ b/tests/test_imd_converter/test_process_doc1_latex__tex_.tex
@@ -103,7 +103,7 @@ Some inline math: \(x = y + z\)
 Some display math:
 
 \[
-\begin{equation} 
+\begin{equation}
   f\left(k\right) = \binom{n}{k} p^k\left(1-p\right)^{n-k}
 \end{equation}
 \]
@@ -116,12 +116,17 @@ This is some more text.
 
 \begin{Shaded}
 \begin{Highlighting}[]
+\ImportTok{import}\NormalTok{ os}
 \NormalTok{a }\OperatorTok{=} \DecValTok{1}
+\NormalTok{b }\OperatorTok{=} \StringTok{"I'm a replacement"}
+\NormalTok{c }\OperatorTok{=} \FloatTok{1.0}
 \BuiltInTok{print}\NormalTok{(}\SpecialStringTok{f"a = }\SpecialCharTok{\{a\}}\SpecialStringTok{"}\NormalTok{)}
 \end{Highlighting}
 \end{Shaded}
 
 a = 1
+
+I'm a replacement
 
 \begin{Shaded}
 \begin{Highlighting}[]
@@ -130,7 +135,18 @@ a = 1
 \end{Highlighting}
 \end{Shaded}
 
+\begin{verbatim}
+{include: false}
+\end{verbatim}
+
+\begin{verbatim}
+a += 1
+print(f"a = {a}")
+\end{verbatim}
+
 a = 3
+
+3
 
 \begin{Shaded}
 \begin{Highlighting}[]

--- a/tests/test_imd_converter/test_process_doc1_markdown__md_.md
+++ b/tests/test_imd_converter/test_process_doc1_markdown__md_.md
@@ -21,7 +21,7 @@ Some inline math: $x = y + z$
 Some display math:
 
 $$
-\begin{equation} 
+\begin{equation}
   f\left(k\right) = \binom{n}{k} p^k\left(1-p\right)^{n-k}
 \end{equation}
 $$
@@ -34,7 +34,10 @@ This is some more text.
 
 ::: {.code-cell}
 ``` {.python}
+import os
 a = 1
+b = "I'm a replacement"
+c = 1.0
 print(f"a = {a}")
 ```
 
@@ -43,8 +46,21 @@ a = 1
 :::
 :::
 
+I\'m a replacement
+
 ::: {.code-cell}
 ``` {.python}
+a += 1
+print(f"a = {a}")
+```
+:::
+
+::: {.imd-chunk type="python"}
+``` {.options}
+{include: false}
+```
+
+``` {.content}
 a += 1
 print(f"a = {a}")
 ```
@@ -55,6 +71,8 @@ print(f"a = {a}")
 a = 3
 :::
 :::
+
+3
 
 ``` {.julia}
 using Calculus

--- a/tests/test_imd_converter/test_process_doc1_rst__rst_.rst
+++ b/tests/test_imd_converter/test_process_doc1_rst__rst_.rst
@@ -21,7 +21,7 @@ Some display math:
 .. math::
 
 
-   \begin{equation} 
+   \begin{equation}
      f\left(k\right) = \binom{n}{k} p^k\left(1-p\right)^{n-k}
    \end{equation}
 
@@ -35,16 +35,32 @@ This is some more text.
 
    .. code:: python
 
+      import os
       a = 1
+      b = "I'm a replacement"
+      c = 1.0
       print(f"a = {a}")
 
    .. container:: outputs
 
       a = 1
 
+I'm a replacement
+
 .. container:: code-cell
 
    .. code:: python
+
+      a += 1
+      print(f"a = {a}")
+
+.. container:: imd-chunk
+
+   .. code:: options
+
+      {include: false}
+
+   .. code:: content
 
       a += 1
       print(f"a = {a}")
@@ -54,6 +70,8 @@ This is some more text.
    .. container:: outputs
 
       a = 3
+
+3
 
 .. code:: julia
 


### PR DESCRIPTION
Chunks are now reformatted, to play nicely with pandoc. Then chunk processing occurs after pandoc conversion. This allows concurrent processing of other pandoc elements.

The chunks now also may return metadata. This is utilised by ``PandocChunk`` to poll the kernel for current variables and return them as part of the metadata.

Both of these improvements are then utilised to walk through the document and concurrently process chunks and replace ``pf.Str`` placeholders, of the form ``{{<chunk name>:<variable name>}}``, with current variables from the kernel.